### PR TITLE
Change error management to bit-error-rate

### DIFF
--- a/src/il2p.c
+++ b/src/il2p.c
@@ -21,7 +21,7 @@ void InitIL2P(IL2P_TRX_struct *self){
     self->RXState = IL2P_RX_SEARCH;
     self->TransparentMode = 0;
     self->FSK4Syncword = 0;
-    self->SyncTolerance = 1;
+    self->SyncTolerance = 0;
     self->InvertRXData = 0;
     self->TrailingCRC = 1;
     self->SisterLastChecksum = -1;

--- a/src/vector_errors.c
+++ b/src/vector_errors.c
@@ -11,14 +11,16 @@ void CopyMessage(int *in, int *out, int size) {
 	}
 }
 
-void GenBERErrorVector(int *buffer, int bits_per_word, int size, float ber) {
+int GenBERErrorVector(int *buffer, int bits_per_word, int size, float ber) {
 	int bit_count = size * bits_per_word;
 	int byte_index = 0;
 	int bit_index = 0;
 	int work = 0;
+	int bit_error_count = 0;
 	for (int i = 0; i < bit_count; i++) {
 		if (((double)rand() / (double)RAND_MAX) < ber) {
 			work |= 1;
+			bit_error_count++;
 		}
 		bit_index++;
 		if (bit_index >= bits_per_word) {
@@ -28,6 +30,7 @@ void GenBERErrorVector(int *buffer, int bits_per_word, int size, float ber) {
 		}
 		work <<= 1;
 	}
+	return bit_error_count;
 }
 
 void CombineVectors(int *in1, int *in2, int *out, int count) {

--- a/src/vector_errors.h
+++ b/src/vector_errors.h
@@ -2,7 +2,7 @@
 #ifndef VECTOR_ERROR_H
 #define	VECTOR_ERROR_H
 
-void GenBERErrorVector(int *, int , int , float );
+int GenBERErrorVector(int *, int , int , float );
 int CompareVectors(uint8_t *, uint8_t *, int );
 
 #endif


### PR DESCRIPTION
Convert from specifying number of bytes in error to specifying bit error rate for each batch of runs. Allows more granular results.